### PR TITLE
Fix missing username query on Python 3

### DIFF
--- a/sharepoint/cmd.py
+++ b/sharepoint/cmd.py
@@ -61,7 +61,9 @@ def main():
         username, password = options.username, options.password
 
     if not username:
-        username = raw_input("Username: ")
+        sys.stdout.write("Username: ")
+        sys.stdout.flush()
+        username = sys.stdin.readline().strip()
     if not password:
         from getpass import getpass
         password = getpass()


### PR DESCRIPTION
Broke the `sharepoint` command when I tried it.