### PR TITLE
Fix #10 when comparing 'string' field types.

### DIFF
--- a/sharepoint/lists/types.py
+++ b/sharepoint/lists/types.py
@@ -386,7 +386,8 @@ class CalculatedField(Field):
     group_multi = 2
     immutable = True
     
-    types = {'float': float}
+    types = {'float': float,
+             'string': str}
     type_names = {float: 'float',
                   str: 'text',
                   int: 'int'}


### PR DESCRIPTION
Ran into issue #10 with a 'string' field type, it is likely other field types would still trip this but it's a start. Reference for Calculated Field type is here: http://social.technet.microsoft.com/wiki/contents/articles/21801.sharepoint-a-complete-guide-to-getting-and-setting-fields-using-c.aspx#Setting_and_Getting_a_Calculated_Field