### PR TITLE
Return list comprehension. map() is a generator.

### DIFF
--- a/sharepoint/lists/types.py
+++ b/sharepoint/lists/types.py
@@ -90,7 +90,7 @@ class Field(object):
                 # if we have [['']], then remove the last entry
                 if values and values[-1] and not values[-1][0]:
                     del values[-1]
-                return map(self._parse, values)
+                return [self._parse(v) for v in values]
             else:
                 return [self._parse(v) for v in values if v not in empty_values]
         elif self.group_multi:


### PR DESCRIPTION
Returning a generator means that the field value will be empty if it's iterated a second time in Python 3. That would be unexpected for most users.